### PR TITLE
remove useTLS function argument

### DIFF
--- a/LightMQTT.swift
+++ b/LightMQTT.swift
@@ -80,7 +80,7 @@ final class LightMQTT {
             return false
         }
 
-        guard let (input, output) = openStreams(host: host, port: port, useTLS: useTLS) else {
+        guard let (input, output) = openStreams(host: host, port: port) else {
             return false
         }
 
@@ -134,7 +134,7 @@ final class LightMQTT {
 
     // MARK: - Socket connection
 
-    private func openStreams(host: String, port: Int, useTLS: Bool) -> (inputStream: InputStream, outputStream: OutputStream)? {
+    private func openStreams(host: String, port: Int) -> (inputStream: InputStream, outputStream: OutputStream)? {
         var inputStream: InputStream?
         var outputStream: OutputStream?
 


### PR DESCRIPTION
I noticed with the integration of this, that it's redundant to pass the `useTLS` value around as an argument. It's set already, and doesn't have an optional state to protect against. So the class's instance variable (er, property) can just be referenced directly. Personally, I would put a `self.useTLS` there, but you don't seem to be following that pattern at the moment, so I didn't.