### PR TITLE
username & password

### DIFF
--- a/LightMQTT.swift
+++ b/LightMQTT.swift
@@ -80,7 +80,7 @@ final class LightMQTT {
             return false
         }
 
-        guard let (input, output) = openStreams(host: host, port: port, useTLS: useTLS) else {
+        guard let (input, output) = openStreams(host: host, port: port) else {
             return false
         }
 
@@ -134,7 +134,7 @@ final class LightMQTT {
 
     // MARK: - Socket connection
 
-    private func openStreams(host: String, port: Int, useTLS: Bool) -> (inputStream: InputStream, outputStream: OutputStream)? {
+    private func openStreams(host: String, port: Int) -> (inputStream: InputStream, outputStream: OutputStream)? {
         var inputStream: InputStream?
         var outputStream: OutputStream?
 


### PR DESCRIPTION
Initial implementation. I added another helper to encode the 2 byte utf8 preambles. This could be used throughout the rest of the code as well, but I like keeping each PR to one thing. If you want, I'll do another applied elsewhere.