### PR TITLE
AND should be OR <headshake>

### DIFF
--- a/LightMQTT.swift
+++ b/LightMQTT.swift
@@ -454,7 +454,7 @@ final class LightMQTT {
             var byte = UInt8(workingLength & 0x7F)
             workingLength >>= 7
             if workingLength > 0 {
-                byte &= 0x80
+                byte |= 0x80
             }
             remainingBytes.append(byte)
         }


### PR DESCRIPTION
Shame on me. There's a bug in the variable length encoding when packets get larger than 127. My testing apparently hadn't gone up there yet. When I started using long passkeys.... The "continuation" bit needs to be OR'ed in, not AND'ed.