### PR TITLE
templatable clientid

### DIFF
--- a/LightMQTT.swift
+++ b/LightMQTT.swift
@@ -61,6 +61,15 @@ final class LightMQTT {
         var concretePort: Int {
             return port ?? (useTLS ? 8883 : 1883)
         }
+
+        fileprivate var concreteClientId:String {
+            var result = clientId ?? "%%%%"
+            while let range = result.range(of: "%") {
+                let hexNibbles = String(format: "%02X", Int(arc4random() & 0xFF))
+                result.replaceSubrange(range, with: hexNibbles)
+            }
+            return result
+        }
     }
 
     private var options: Options
@@ -329,10 +338,7 @@ final class LightMQTT {
      */
 
     private func mqttConnect(keepalive: UInt16) {
-        let baseIntA = Int(arc4random() % 65535)
-        let baseIntB = Int(arc4random() % 65535)
-
-        let clientId = options.clientId ?? String(format: "%04X%04X", baseIntA, baseIntB)
+        let clientId = options.concreteClientId
 
         /**
          * |----------------------------------------------------------------------------------


### PR DESCRIPTION
The basic approach is similar to port:Int? Add a concreteClientId accessor (I think these should be `fileprivate` -- yeck -- so that you don't get get it as an autocomplete option in client code).

Any `%` character is converted to an a single hex byte. This generalizes to the current approach as `%%%%` (4 bytes of randomness). In fact... instead of clientId being nil'able, it *could* just be initialized to that value by default. I guess I kind of like the idea that nil is the default and it just does the right thing though.